### PR TITLE
timezone field missing

### DIFF
--- a/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Schema/XSD/DateTime.js
+++ b/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Schema/XSD/DateTime.js
@@ -60,7 +60,8 @@ Jsonix.Schema.XSD.DateTime = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
 			hour : value.getHours(),
 			minute : value.getMinutes(),
 			second : value.getSeconds(),
-			fractionalSecond : (value.getMilliseconds() / 1000)
+			fractionalSecond : (value.getMilliseconds() / 1000),
+			timezone: value.getTimezoneOffset()
 		}));
 	},
 	isInstance : function(value) {


### PR DESCRIPTION
fix: timezone field missing in DateTime print method https://github.com/highsource/jsonix/issues/8
