### PR TITLE
Update DateTime.js

### DIFF
--- a/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Schema/XSD/DateTime.js
+++ b/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Schema/XSD/DateTime.js
@@ -46,7 +46,7 @@ Jsonix.Schema.XSD.DateTime = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
 
 		//		
 		if (Jsonix.Util.NumberUtils.isInteger(calendar.timezone)) {
-			return new Date(date.getTime() - (60000 * date.getTimezoneOffset()) + (calendar.timezone * 60000));
+			return new Date(date.getTime() - (60000 * date.getTimezoneOffset()) - (calendar.timezone * 60000));
 		} else {
 			return new Date(date.getTime() - (60000 * date.getTimezoneOffset()));
 		}
@@ -61,7 +61,7 @@ Jsonix.Schema.XSD.DateTime = Jsonix.Class(Jsonix.Schema.XSD.Calendar, {
 			minute : value.getMinutes(),
 			second : value.getSeconds(),
 			fractionalSecond : (value.getMilliseconds() / 1000),
-			timezone: value.getTimezoneOffset()
+			timezone: -value.getTimezoneOffset()
 		}));
 	},
 	isInstance : function(value) {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
The time-zone offset is the difference, in minutes, between UTC and local time.

I think it would be rather. 

For example: I have XML <customerOrder updated="2014-05-10T00:00:00.000+04:00"></customerOrder>, from my server in Moscow. And I have to get customerOrder.updated.toString() -> "Sat May 10 2014 02:00:00 GMT+0600" in Ekaterinburg (UTC+06:00) or in XML - <customerOrder updated="2014-05-10T02:00:00+06:00"/>

Is this correct?
