### PR TITLE
Attr.nodeValue' is deprecated. Please use 'value' instead. 

### DIFF
--- a/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/XML/Input.js
+++ b/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/XML/Input.js
@@ -329,7 +329,7 @@ Jsonix.XML.Input = Jsonix.Class({
 			throw new Error("Invalid attribute index [" + index + "].");
 		}
 		var attribute = attributes[index];
-		return attribute.nodeValue;
+		return attribute.value;
 	},
 	getElement : function() {
 		if (this.eventType === 1 || this.eventType === 2) {


### PR DESCRIPTION
`return attribute.nodeValue;`

Should we change to value?
