### PR TITLE
Update QName.js to safely handle null value

### DIFF
--- a/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/XML/QName.js
+++ b/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/XML/QName.js
@@ -106,7 +106,7 @@ Jsonix.XML.QName.fromObject = function(object) {
 	if (object instanceof Jsonix.XML.QName || (Jsonix.Util.Type.isString(object.CLASS_NAME) && object.CLASS_NAME === 'Jsonix.XML.QName')) {
 		return object;
 	}
-	var localPart = object.localPart||object.lp||null;
+	var localPart = object.localPart||object.lp||'';
 	Jsonix.Util.Ensure.ensureString(localPart);
 	var namespaceURI = object.namespaceURI||object.ns||'';
 	var prefix = object.prefix||object.p||'';


### PR DESCRIPTION
Rather than explicitly setting `var localPart` to `null` when either of the preceding checks are null, this change sets an empty string value to prevent an exception from being thrown on line 110 inside the `ensureString` check.
