### PR TITLE
Updated test to reflect #157

### DIFF
--- a/nodejs/tests/basic/tests/gh56.js
+++ b/nodejs/tests/basic/tests/gh56.js
@@ -1,59 +1,59 @@
 var Jsonix = require('jsonix').Jsonix;
 var Mapping = {
-    name: 'Mapping',
-    typeInfos: [{
-        type: 'classInfo',
-        localName: 'ElementRefType',
-        propertyInfos: [{
-            type: 'elementRef',
-            name: 'data',
-            elementName : 'number',
-            typeInfo: 'Number'
-        }]
-    }, {
-        type: 'classInfo',
-        localName: 'ElementRefsType',
-        propertyInfos: [{
-            type: 'elementRefs',
-            name: 'data',
-            wrapperElementName: 'numbers',
-            collection: true,
-            elementTypeInfos: [{
-                elementName: 'long',
-                typeInfo: 'Long'
-            }, {
-                elementName: 'integer',
-                typeInfo: 'Integer'
-            }]
-        }]
-    }],
-    elementInfos: [{
-        elementName: 'ref',
-        typeInfo: 'Mapping.ElementRefType'
-    }, {
-        elementName: 'refs',
-        typeInfo: 'Mapping.ElementRefsType'
-    }, {
-        elementName: { localPart: 'long', namespaceURI : 'urn:test'},
+	name: 'Mapping',
+	typeInfos: [{
+		type: 'classInfo',
+		localName: 'ElementRefType',
+		propertyInfos: [{
+			type: 'elementRef',
+			name: 'data',
+			elementName : 'number',
+			typeInfo: 'Number'
+		}]
+	}, {
+		type: 'classInfo',
+		localName: 'ElementRefsType',
+		propertyInfos: [{
+			type: 'elementRefs',
+			name: 'data',
+			wrapperElementName: 'numbers',
+			collection: true,
+			elementTypeInfos: [{
+				elementName: 'long',
+				typeInfo: 'Long'
+			}, {
+				elementName: 'integer',
+				typeInfo: 'Integer'
+			}]
+		}]
+	}],
+	elementInfos: [{
+		elementName: 'ref',
+		typeInfo: 'Mapping.ElementRefType'
+	}, {
+		elementName: 'refs',
+		typeInfo: 'Mapping.ElementRefsType'
+	}, {
+		elementName: { localPart: 'long', namespaceURI : 'urn:test'},
 	substitutionHead: 'number',
-        typeInfo: 'Long'
-    }, {
-        elementName: { localPart: 'integer', namespaceURI : 'urn:test'},
+		typeInfo: 'Long'
+	}, {
+		elementName: { localPart: 'integer', namespaceURI : 'urn:test'},
 	substitutionHead: 'number',
-        typeInfo: 'Integer'
-    }]
+		typeInfo: 'Integer'
+	}]
 };
 module.exports = {
 	"MarshallsRef" : function(test) {
 		var context = new Jsonix.Context([ Mapping ], { namespacePrefixes : { 'urn:test' : 'test' } });
 		var marshaller = context.createMarshaller();
-		test.equal('<ref xmlns:test="urn:test"><test:integer>123</test:integer></ref>', marshaller.marshalString({
+		test.equal('<ref xmlns:test="urn:test"><test:integer>111111111111111111</test:integer></ref>', marshaller.marshalString({
 			name : 'ref',
-			value : { data : { name : 'test:integer', value : 123 } }
+			value : { data : { name : 'test:integer', value : '111111111111111111' } }
 		}));
-		test.equal('<ref xmlns:test="urn:test"><test:integer>321</test:integer></ref>', marshaller.marshalString({
+		test.equal('<ref xmlns:test="urn:test"><test:integer>222222222222222222</test:integer></ref>', marshaller.marshalString({
 			name : 'ref',
-			value : { data : { 'test:integer' : 321 } }
+			value : { data : { 'test:integer' : '222222222222222222' } }
 		}));
 		test.done();
 	}


### PR DESCRIPTION
Updated test to fail under conditions described by #157

Note how the unmarshalled numbers lose precision:

```
AssertionError: '<ref xmlns:test="urn:test"><test:integer>111111111111111111</test:integer></ref>' == '<ref xmlns:test="urn:test"><test:integer>111111111111111100</test:integer></ref>'

AssertionError: '<ref xmlns:test="urn:test"><test:integer>222222222222222222</test:integer></ref>' == '<ref xmlns:test="urn:test"><test:integer>222222222222222200</test:integer></ref>'
```