### PR TITLE
Fix RangeError when decoding base64

### DIFF
--- a/nodejs/scripts/jsonix.js
+++ b/nodejs/scripts/jsonix.js
@@ -4361,7 +4361,7 @@ Jsonix.Schema.XSD.Base64Binary = Jsonix.Class(Jsonix.Schema.XSD.AnySimpleType, {
 
 		input = text.replace(/[^A-Za-z0-9\+\/\=]/g, "");
 
-		var length = (input.length / 4) * 3;
+		var length = Math.floor(input.length / 4 * 3);
 		if (input.charAt(input.length - 1) === "=") {
 			length--;
 		}


### PR DESCRIPTION
This PR fixes a `RangeError: Invalid array length` error that can be thrown when decoding a Base64Binary. 

It may also be worth to look into the latest version of the `Base64Binary` code that this was based on, and which is available [here](https://github.com/danguer/blog-examples/blob/master/js/base64-binary.js) (and that was first introduced in [this blog post](http://blog.danguer.com/2011/10/24/base64-binary-decoding-in-javascript/)).

<hr>

**Edit:** On closer inspection, the value that I was trying to decode seems to be truncated/incomplete. Still, it may be worth to update the `Base64Binary` code to the one that I have linked to, as jsonix currently fails with an unclear error if can't decode a base64 value. For reference, this is the "weird" base64 value that I was trying to decode: `BwABBJQ1gJDUCAAAAAAA=`

