### PR TITLE
Add CDATA support

### DIFF
--- a/dist/Jsonix-min.js
+++ b/dist/Jsonix-min.js
@@ -650,6 +650,12 @@ if(Jsonix.Util.Type.isFunction(this.document.createTextNode)){d=this.document.cr
 }else{throw new Error("Could not create a text node.")
 }}this.peek().appendChild(d);
 return d
+},writeCDATA:function(c){var d;
+if(Jsonix.Util.Type.isFunction(this.document.createCDATASection)){d=this.document.createCDATASection(c)
+}else{if(this.xmldom){d=this.xmldom.createCDATASection(c)
+}else{throw new Error("Could not create a CDATA section node.")
+}}this.peek().appendChild(d);
+return d
 },writeAttribute:function(t,k){Jsonix.Util.Ensure.ensureString(k);
 Jsonix.Util.Ensure.ensureObject(t);
 var n=t.localPart||t.lp||null;
@@ -1149,13 +1155,16 @@ Jsonix.Util.Ensure.ensureObject(e.attributes);
 var d=this.attributeName.key;
 e.attributes[d]=this
 },CLASS_NAME:"Jsonix.Model.AttributePropertyInfo"});
-Jsonix.Model.ValuePropertyInfo=Jsonix.Class(Jsonix.Model.SingleTypePropertyInfo,{initialize:function(b){Jsonix.Util.Ensure.ensureObject(b);
-Jsonix.Model.SingleTypePropertyInfo.prototype.initialize.apply(this,[b])
+Jsonix.Model.ValuePropertyInfo=Jsonix.Class(Jsonix.Model.SingleTypePropertyInfo,{initialize:function(d){Jsonix.Util.Ensure.ensureObject(d);
+Jsonix.Model.SingleTypePropertyInfo.prototype.initialize.apply(this,[d]);
+var c=d.asCDATA||d.c||false;
+this.asCDATA=c
 },unmarshal:function(e,f,h){var g=f.getElementText();
 return this.unmarshalValue(g,e,f,h)
 },marshal:function(g,e,f,h){if(!Jsonix.Util.Type.exists(g)){return
-}f.writeCharacters(this.print(g,e,f,h))
-},buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
+}if(this.asCDATA){f.writeCDATA(this.print(g,e,f,h))
+}else{f.writeCharacters(this.print(g,e,f,h))
+}},buildStructure:function(c,d){Jsonix.Util.Ensure.ensureObject(d);
 if(Jsonix.Util.Type.exists(d.elements)){throw new Error("The structure already defines element mappings, it cannot define a value property.")
 }else{d.value=this
 }},CLASS_NAME:"Jsonix.Model.ValuePropertyInfo"});

--- a/nodejs/tests/basic/tests/One/Mappings.js
+++ b/nodejs/tests/basic/tests/One/Mappings.js
@@ -5,6 +5,9 @@ module.exports.One = One;
 One.ValueType = new Jsonix.Model.ClassInfo({
 	name : "One.ValueType"
 });
+One.ValueAsCDATAType = new Jsonix.Model.ClassInfo({
+	name : "One.ValueAsCDATAType"
+});
 One.AnyAttributeType = new Jsonix.Model.ClassInfo({
 	name : "One.AnyAttributeType"
 });
@@ -36,6 +39,11 @@ One.ElementMapType = new Jsonix.Model.ClassInfo({
 One.ValueType.properties = [ new Jsonix.Model.ValuePropertyInfo({
 	name : "value",
 	typeInfo : Jsonix.Schema.XSD.String.INSTANCE
+}) ];
+One.ValueAsCDATAType.properties = [ new Jsonix.Model.ValuePropertyInfo({
+	name : "value",
+	typeInfo : Jsonix.Schema.XSD.String.INSTANCE,
+	asCDATA: true
 }) ];
 One.AnyAttributeType.properties = [ new Jsonix.Model.AnyAttributePropertyInfo({
 	name : "attributes"
@@ -213,7 +221,7 @@ One.AnyElementType.properties = [ new Jsonix.Model.AttributePropertyInfo({
 }) ];
 
 One.SimpleTypesType.properties = [
-		//                                   
+		//
 		new Jsonix.Model.ElementPropertyInfo({
 			name : "date",
 			typeInfo : Jsonix.Schema.XSD.DateAsDate.INSTANCE
@@ -305,6 +313,9 @@ One.ElementMapType.properties = [ new Jsonix.Model.ElementMapPropertyInfo({
 One.elementInfos = [ {
 	elementName : new Jsonix.XML.QName('value'),
 	typeInfo : One.ValueType
+}, {
+	elementName : new Jsonix.XML.QName('valueAsCDATA'),
+	typeInfo : One.ValueAsCDATAType
 }, {
 	elementName : new Jsonix.XML.QName('anyAttribute'),
 	typeInfo : One.AnyAttributeType

--- a/nodejs/tests/basic/tests/one.js
+++ b/nodejs/tests/basic/tests/one.js
@@ -81,7 +81,7 @@ module.exports =
 		test.equal('c', result.value.attributes['{urn:c}c']);
 		test.done();
 	},
-	
+
 	"MarhshalAttributeType" : function(test) {
 		var context = new Jsonix.Context([ One ], {
 			namespacePrefixes : {}
@@ -125,7 +125,7 @@ module.exports =
 		test.equal('test', result.value.attribute);
 		test.done();
 	},
-	
+
 	"MarhshalElementType" : function(test) {
 		var context = new Jsonix.Context([ One ]);
 		var marshaller = context.createMarshaller();
@@ -145,7 +145,7 @@ module.exports =
 		test.ok(serializedNode.length > 5);
 		test.done();
 	},
-	
+
 	"UnmarhshalElementType" : function(test) {
 		var context = new Jsonix.Context([ One ]);
 		var unmarshaller = context.createUnmarshaller();
@@ -190,7 +190,7 @@ module.exports =
 		test.equal('f', result.value.items[2]);
 		test.done();
 	},
-	
+
 	"MarhshalElementsType" : function(test) {
 		var context = new Jsonix.Context([ One ]);
 		var marshaller = context.createMarshaller();
@@ -226,7 +226,7 @@ module.exports =
 		test.ok(serializedNode.length > 5);
 		test.done();
 	},
-	
+
 	"UnmarhshalElementsType" : function(test) {
 		var context = new Jsonix.Context([ One ]);
 		var unmarshaller = context.createUnmarshaller();
@@ -282,7 +282,7 @@ module.exports =
 		console.log(marshaller.marshalString(result));
 		test.done();
 	},
-	
+
 	"MarhshalElementRefType" : function(test) {
 		var context = new Jsonix.Context([ One, Two ], {
 			namespacePrefixes : {
@@ -390,7 +390,7 @@ module.exports =
 		test.equal('twelve', result.value.mix[2]);
 		test.done();
 	},
-	
+
 	"UnmarshalElementRefsType" : function(test) {
 		var context = new Jsonix.Context([ One ]);
 		var unmarshaller = context.createUnmarshaller();
@@ -495,7 +495,7 @@ module.exports =
 					}
 				}, 'three', Jsonix.DOM.parse('<node>four</node>').documentElement ]
 			}
-	
+
 		};
 		var node = marshaller.marshalDocument(value);
 		var serializedNode = Jsonix.DOM.serialize(node);
@@ -503,7 +503,7 @@ module.exports =
 		test.ok(serializedNode.length > 5);
 		test.done();
 	},
-	
+
 	"UnmarhshalAnyElementType" : function(test) {
 		var context = new Jsonix.Context([ One, Two ]);
 		var unmarshaller = context.createUnmarshaller();
@@ -561,7 +561,7 @@ module.exports =
 		test.ok(serializedNode.length > 5);
 		test.done();
 	},
-	
+
 	"UnmarhshalSimpleTypesType" : function(test) {
 		var context = new Jsonix.Context([ One ]);
 		var unmarshaller = context.createUnmarshaller();
@@ -598,7 +598,7 @@ module.exports =
 		test.equal(1.1, result.value['double']);
 		test.equal(2, result.value.integer);
 		test.equal('three', result.value.string);
-	
+
 		//
 		test.equal(2000, result.value.dates[0].getFullYear());
 		test.equal(2001, result.value.dates[1].getFullYear());
@@ -614,7 +614,7 @@ module.exports =
 		test.equal(7, result.value.doublesList[2][1]);
 		test.done();
 	},
-	
+
 	"UnmarhshalMapElementType" : function(test) {
 		var context = new Jsonix.Context([ One ]);
 		var unmarshaller = context.createUnmarshaller();
@@ -723,6 +723,33 @@ module.exports =
 		var context = new Jsonix.Context([ One, Two ]);
 		var unmarshaller = context.createUnmarshaller();
 		var text = '<string>text</string>';
+		var result = unmarshaller.unmarshalString(text);
+		test.equal('string', result.name.localPart);
+		test.equal('text', result.value);
+		test.done();
+	},
+	"MarshalCDATAValueType" : function(test)
+	{
+		var context = new Jsonix.Context([ One ]);
+		var marshaller = context.createMarshaller();
+		var value = {
+			name : {
+				localPart : "valueAsCDATA"
+			},
+			value : {
+				value : 'test<>?\'"&'
+			}
+		};
+		var result = marshaller.marshalString(value);
+		console.log(result);
+		test.ok(result === '<valueAsCDATA><![CDATA[test<>?\'"&]]></valueAsCDATA>');
+		test.done();
+	},
+	"UnmarshalCDATAValueType": function (test)
+	{
+		var context = new Jsonix.Context([ One ]);
+		var unmarshaller = context.createUnmarshaller();
+		var text = '<valueAsCDATA><![CDATA[test<>?\'"&]]></valueAsCDATA>';
 		var result = unmarshaller.unmarshalString(text);
 		test.equal('string', result.name.localPart);
 		test.equal('text', result.value);

--- a/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Model/ValuePropertyInfo.js
+++ b/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Model/ValuePropertyInfo.js
@@ -2,6 +2,9 @@ Jsonix.Model.ValuePropertyInfo = Jsonix.Class(Jsonix.Model.SingleTypePropertyInf
 	initialize : function(mapping) {
 		Jsonix.Util.Ensure.ensureObject(mapping);
 		Jsonix.Model.SingleTypePropertyInfo.prototype.initialize.apply(this, [ mapping ]);
+
+		var c = mapping.asCDATA || mapping.c || false;
+		this.asCDATA = c;
 	},
 	unmarshal : function(context, input, scope) {
 		var text = input.getElementText();
@@ -11,7 +14,12 @@ Jsonix.Model.ValuePropertyInfo = Jsonix.Class(Jsonix.Model.SingleTypePropertyInf
 		if (!Jsonix.Util.Type.exists(value)) {
 			return;
 		}
-		output.writeCharacters(this.print(value, context, output, scope));
+
+		if (this.asCDATA) {
+			output.writeCDATA(this.print(value, context, output, scope));
+		} else {
+			output.writeCharacters(this.print(value, context, output, scope));
+		}
 	},
 	buildStructure : function(context, structure) {
 		Jsonix.Util.Ensure.ensureObject(structure);

--- a/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/XML/Output.js
+++ b/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/XML/Output.js
@@ -95,6 +95,19 @@ Jsonix.XML.Output = Jsonix.Class({
 		return node;
 
 	},
+	writeCDATA : function(text) {
+		var node;
+		if (Jsonix.Util.Type.isFunction(this.document.createCDATASection))	{
+			node = this.document.createCDATASection(text);
+		}
+		else if (this.xmldom) {
+			node = this.xmldom.createCDATASection(text);
+		} else {
+			throw new Error("Could not create a CDATA section node.");
+		}
+		this.peek().appendChild(node);
+		return node;
+	},
 	writeAttribute : function(name, value) {
 		Jsonix.Util.Ensure.ensureString(value);
 		Jsonix.Util.Ensure.ensureObject(name);
@@ -132,7 +145,7 @@ Jsonix.XML.Output = Jsonix.Class({
 			}
 			this.declareNamespace(namespaceURI, prefix);
 		}
-		
+
 	},
 	writeNode : function(node) {
 		var importedNode;
@@ -241,7 +254,7 @@ Jsonix.XML.Output = Jsonix.Class({
 		if (Jsonix.Util.Type.isString(p))
 		{
 			var oldp = nspItem[ns];
-			// If prefix is already declared and equals the proposed prefix 
+			// If prefix is already declared and equals the proposed prefix
 			if (p === oldp)
 			{
 				// Nothing to do

--- a/scripts/src/test/javascript/org/hisrc/jsonix/samples/one/One.js
+++ b/scripts/src/test/javascript/org/hisrc/jsonix/samples/one/One.js
@@ -3,6 +3,9 @@ One = {};
 One.ValueType = new Jsonix.Model.ClassInfo({
 	name : "One.ValueType"
 });
+One.ValueAsCDATAType = new Jsonix.Model.ClassInfo({
+	name : "One.ValueAsCDATAType"
+});
 One.AnyAttributeType = new Jsonix.Model.ClassInfo({
 	name : "One.AnyAttributeType"
 });
@@ -34,6 +37,11 @@ One.ElementMapType = new Jsonix.Model.ClassInfo({
 One.ValueType.properties = [ new Jsonix.Model.ValuePropertyInfo({
 	name : "value",
 	typeInfo : Jsonix.Schema.XSD.String.INSTANCE
+}) ];
+One.ValueAsCDATAType.properties = [ new Jsonix.Model.ValuePropertyInfo({
+	name : "value",
+	typeInfo : Jsonix.Schema.XSD.String.INSTANCE,
+	asCDATA: true
 }) ];
 One.AnyAttributeType.properties = [ new Jsonix.Model.AnyAttributePropertyInfo({
 	name : "attributes"
@@ -211,7 +219,7 @@ One.AnyElementType.properties = [ new Jsonix.Model.AttributePropertyInfo({
 }) ];
 
 One.SimpleTypesType.properties = [
-		//                                   
+		//
 		new Jsonix.Model.ElementPropertyInfo({
 			name : "date",
 			typeInfo : Jsonix.Schema.XSD.DateAsDate.INSTANCE
@@ -303,6 +311,9 @@ One.ElementMapType.properties = [ new Jsonix.Model.ElementMapPropertyInfo({
 One.elementInfos = [ {
 	elementName : new Jsonix.XML.QName('value'),
 	typeInfo : One.ValueType
+}, {
+	elementName : new Jsonix.XML.QName('valueAsCDATA'),
+	typeInfo : One.ValueAsCDATAType
 }, {
 	elementName : new Jsonix.XML.QName('anyAttribute'),
 	typeInfo : One.AnyAttributeType

--- a/scripts/src/test/javascript/org/hisrc/jsonix/samples/one/test/OneTest.js
+++ b/scripts/src/test/javascript/org/hisrc/jsonix/samples/one/test/OneTest.js
@@ -688,7 +688,7 @@ function testOneUnmarhshalUnexpectedElementType() {
 	var text = '<element>' +
 	//
 	'<unexpected>1<two/>3<four>5</four>6</unexpected>' +
-	// 
+	//
 	'<element>earth</element>' +
 	//
 	'</element>';
@@ -713,4 +713,30 @@ function testOneMarhshalUnexpectedElementType() {
 	var serializedNode = Jsonix.DOM.serialize(node);
 	logger.debug(serializedNode);
 	assertTrue(serializedNode.length > 5);
+}
+
+function testOneMarshalCDATAValueType()
+{
+	var context = new Jsonix.Context([ One ]);
+	var marshaller = context.createMarshaller();
+	var value = {
+		name : {
+			localPart : "valueAsCDATA"
+		},
+		value : {
+			value : 'test<>?\'"&'
+		}
+	};
+	var result = marshaller.marshalString(value);
+	logger.debug(result);
+	assertTrue(result === '<valueAsCDATA><![CDATA[test<>?\'"&]]></valueAsCDATA>');
+}
+function testOneUnmarshalCDATAValueType()
+{
+	var context = new Jsonix.Context([ One ]);
+	var unmarshaller = context.createUnmarshaller();
+	var text = '<valueAsCDATA><![CDATA[test<>?\'"&]]></valueAsCDATA>';
+	var result = unmarshaller.unmarshalString(text);
+	logger.debug(result.value.value);
+	assertTrue(result.value.value === 'test<>?\'"&');
 }


### PR DESCRIPTION
Following https://github.com/highsource/jsonix/issues/173

This PR adds a new data type: `CDATA`, along with a new method in `Output.js` called `writeCDATA`.

The `CDATA` type derives from the `String` type and adds a specific `parse` function for unmarshalling, as well as a `marshal` function which uses the `writeCDATA` function.

The following compiled files are included as well:
* `Jsonix-all.js`
* `Jsonix-min.js`
* `node/scripts/jsonix.js`

I've added basic tests but I'm not sure this is enough so please don't hesitate to tell me if I need to add more. In particular, I couldn't find the right place to add a test that actually does marshalling/unmarshalling.