### PR TITLE
Make sure tests run on Linux, do not use global browserify

### DIFF
--- a/nodejs/tests/browserify/main.js
+++ b/nodejs/tests/browserify/main.js
@@ -1,4 +1,4 @@
-var Jsonix = require('Jsonix').Jsonix;
+var Jsonix = require('jsonix').Jsonix;
 var PO = require('./PO').PO;
 
 // Utility function

--- a/nodejs/tests/browserify/package.json
+++ b/nodejs/tests/browserify/package.json
@@ -1,18 +1,19 @@
 {
-	"name": "jsonix-tests-browserify",
-	"description": "Jsonix Tests Browserify.",
-	"engines": [
-		"node >= 0.8.0"
-	],
-	"main": "main.js",
-	"dependencies": {
-		"jsonix": "2.x.x",
-		"jsonix-schema-compiler": "2.x.x"
-	},
-	"devDependencies" : {
-		"nodeunit" : "~0.x.x"
-	},
-	"scripts": {
-		"prepublish" : "java -jar node_modules/jsonix-schema-compiler/lib/jsonix-schema-compiler-full.jar purchaseorder.xsd -b bindings.xjb"
-	}
+  "name": "jsonix-tests-browserify",
+  "description": "Jsonix Tests Browserify.",
+  "engines": [
+    "node >= 0.8.0"
+  ],
+  "main": "main.js",
+  "dependencies": {
+    "jsonix": "2.x.x",
+    "jsonix-schema-compiler": "2.x.x"
+  },
+  "devDependencies": {
+    "browserify": "^14.4.0",
+    "nodeunit": "~0.x.x"
+  },
+  "scripts": {
+    "prepublish": "java -jar node_modules/jsonix-schema-compiler/lib/jsonix-schema-compiler-full.jar purchaseorder.xsd -b bindings.xjb"
+  }
 }

--- a/nodejs/tests/browserify/pom.xml
+++ b/nodejs/tests/browserify/pom.xml
@@ -29,7 +29,7 @@
 							<goal>exec</goal>
 						</goals>
 						<configuration>
-							<executable>browserify</executable>
+							<executable>node_modules/.bin/browserify</executable>
 							<arguments>
 								<argument>main.js</argument>
 								<argument>-o</argument>


### PR DESCRIPTION
This came up when I was looking at the browserify tests, they don't run on Linux, and they assumed a global browserify install, so I modified that into using a local one in the project