### PR TITLE
Threw exception on prop marshal to get more info from errors

### DIFF
--- a/dist/Jsonix-all.js
+++ b/dist/Jsonix-all.js
@@ -2366,7 +2366,11 @@ Jsonix.Model.ClassInfo = Jsonix
 						var propertyInfo = this.properties[index];
 						var propertyValue = value[propertyInfo.name];
 						if (Jsonix.Util.Type.exists(propertyValue)) {
-							propertyInfo.marshal(propertyValue, context, output, this);
+							try {
+								propertyInfo.marshal(propertyValue, context, output, this);
+							} catch(ex) {
+								throw new Error("Property [" + propertyInfo.name + "] failed to marshal: " + ex);
+							}
 						}
 					}
 				}

--- a/nodejs/scripts/jsonix.js
+++ b/nodejs/scripts/jsonix.js
@@ -2379,7 +2379,11 @@ Jsonix.Model.ClassInfo = Jsonix
 						var propertyInfo = this.properties[index];
 						var propertyValue = value[propertyInfo.name];
 						if (Jsonix.Util.Type.exists(propertyValue)) {
-							propertyInfo.marshal(propertyValue, context, output, this);
+							try {
+								propertyInfo.marshal(propertyValue, context, output, this);
+							} catch(ex) {
+								throw new Error("Property [" + propertyInfo.name + "] failed to marshal: " + ex);
+							}
 						}
 					}
 				}

--- a/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Model/ClassInfo.js
+++ b/scripts/src/main/javascript/org/hisrc/jsonix/Jsonix/Model/ClassInfo.js
@@ -224,7 +224,11 @@ Jsonix.Model.ClassInfo = Jsonix
 						var propertyInfo = this.properties[index];
 						var propertyValue = value[propertyInfo.name];
 						if (Jsonix.Util.Type.exists(propertyValue)) {
-							propertyInfo.marshal(propertyValue, context, output, this);
+							try {
+								propertyInfo.marshal(propertyValue, context, output, this);
+							} catch(ex) {
+								throw new Error("Property [" + propertyInfo.name + "] failed to marshal: " + ex);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Error messages go from

"Argument [2018] must be a string."

to

"Property [header] failed to marshal: Error: Property [date] failed to marshal: Error: Argument [2018] must be an object."

It's not perfect, but an improvement, and a low-risk for breakage